### PR TITLE
Clean visualization test warnings

### DIFF
--- a/R/plotDeltaDistribution.R
+++ b/R/plotDeltaDistribution.R
@@ -168,7 +168,7 @@ plotDeltaDistribution <- function(
     aes.jit <- NULL
     if (!is.null(pruned)) {
         df$pruned <- pruned
-        aes.jit <- ggplot2::aes_string(color = "pruned")
+        aes.jit <- ggplot2::aes(color = .data$pruned)
     }
 
     # Trim dataframe by labels:
@@ -180,7 +180,7 @@ plotDeltaDistribution <- function(
     }
 
     # Making the violin plots.
-    p <- ggplot2::ggplot(data = df, ggplot2::aes_string(x="x", y="values")) + 
+    p <- ggplot2::ggplot(data = df, ggplot2::aes(x=.data$x, y=.data$values)) + 
         ggplot2::xlab("")
 
     if (!is.null(pruned)) {

--- a/R/plotScoreDistribution.R
+++ b/R/plotScoreDistribution.R
@@ -206,7 +206,7 @@ plotScoreDistribution <- function(
 
     # Making the violin plots.
     p <- ggplot2::ggplot(data = df,
-            ggplot2::aes_string(x = "cell.calls", y = "values", fill = "cell.calls")) +
+            ggplot2::aes(x = .data$cell.calls, y = .data$values, fill = .data$cell.calls)) +
         ggplot2::scale_fill_manual(
             name = labels.title,
             breaks = c("assigned", "pruned", "other"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,3 +84,5 @@
         as.matrix(x)
     }
 }
+
+utils::globalVariables(".data")

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -112,7 +112,7 @@ test_that("heatmap is adjusted properly when 'labels.use' yields 1 or 0 labels",
         paste0("disabling normalization"))
 
     expect_equal(
-        suppressMessages(plotScoreHeatmap(results = pred, silent = TRUE,
+        suppressWarnings(plotScoreHeatmap(results = pred, silent = TRUE,
             labels.use = c("A"),
             color = colorRampPalette(c("red", "blue"))(33), # proximal to normalization being turned off
             return.data = TRUE)$color),
@@ -124,7 +124,7 @@ test_that("heatmap is adjusted properly when 'labels.use' yields 1 or 0 labels",
         paste0("ignoring 'labels.use'"))
 
     expect_equal(
-        nrow(suppressMessages(plotScoreHeatmap(results = pred, silent = TRUE,
+        nrow(suppressWarnings(plotScoreHeatmap(results = pred, silent = TRUE,
             labels.use = c("a"),
             return.data = TRUE)$mat)),
         5)
@@ -349,8 +349,10 @@ test_that("heatmap multi-ref - Other typical adjustments throw no unexpected err
     expect_s3_class(plotScoreHeatmap(results = combined,
         normalize = FALSE),
         "gtable")
-    expect_s3_class(plotScoreHeatmap(results = combined,
+    expect_warning(out <- plotScoreHeatmap(results = combined,
         labels.use = c("A", "a")),
+        "disabling normalization")
+    expect_s3_class(out,
         "gtable")
     expect_s3_class(plotScoreHeatmap(results = combined,
         max.labels = 3),


### PR DESCRIPTION
Per #276:
- cleans tests that needlessly report a warning was given
- update ggplot code to use `aes()` directly rather than `aes_string()` per deprecation by ggplot
- Adds a call `utils::globalVariables(".data")` within `R/utils.R` to avoid the undefined global variable Check Note.  If preferred, the alternative to this would be using `#' importFrom ggplot2 .data` and moving ggplot2 from `Suggests:` to `Imports:`.